### PR TITLE
Changed DockerFile and Email_service

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,37 +1,38 @@
 # ---------- Stage 1: Build the application ----------
 FROM maven:3.9.9-eclipse-temurin-21 AS builder
 
-# Set the working directory
 WORKDIR /app
 
-# Copy only the pom.xml first for dependency caching
+# Copy only pom.xml for dependency caching
 COPY pom.xml .
+RUN mvn dependency:go-offline -B
+
+# Copy source
 COPY src ./src
 
-# Package the application (skip tests for faster build, remove if you want tests to run)
+# Build application (skip tests for faster build)
 RUN mvn clean package -DskipTests
 
 # ---------- Stage 2: Create the runtime image ----------
-FROM eclipse-temurin:21-jre AS runtime
+FROM eclipse-temurin:21-jre-alpine AS runtime
 
-# Set a non-root user for security
-RUN useradd -ms /bin/bash springuser
+# Add non-root user
+RUN addgroup --system spring && adduser --system --ingroup spring springuser
 
-# Set working directory
 WORKDIR /app
 
-# Copy the JAR from the builder stage
+# Install CA certificates (with cleanup)
+
+
+# Copy jar from builder
 COPY --from=builder /app/target/*.jar app.jar
 
 # Set ownership
-RUN chown springuser:springuser app.jar
+COPY --chown=springuser:springuser --from=builder /app/target/*.jar app.jar
 
-# Switch to non-root user
 USER springuser
 
-# Expose the port your Spring Boot app runs on (default 8080)
 EXPOSE 8080
 
-# Run the jar
-ENTRYPOINT ["java", "-jar", "app.jar", "--spring.profiles.active=prod"]
-
+ENTRYPOINT ["java", "-jar", "app.jar"]
+CMD ["--spring.profiles.active=prod"]

--- a/server/src/main/java/com/healthmate/service/EmailService.java
+++ b/server/src/main/java/com/healthmate/service/EmailService.java
@@ -6,19 +6,25 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Value;
 
 @Service
 public class EmailService {
 
     @Autowired
     private JavaMailSender mailSender;
-
+    @Value("${spring.mail.username}")
+    private String fromEmail;  
+    
     public void sendOtpEmail(String toEmail, String otp) {
+        
         try {
             System.out.println("[EmailService] Preparing to send OTP to: " + toEmail);
 
             MimeMessage mimeMessage = mailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+
+            helper.setFrom(fromEmail);
 
             helper.setTo(toEmail);
             helper.setSubject("Your HealthMate OTP");

--- a/server/src/main/resources/application-prod.properties
+++ b/server/src/main/resources/application-prod.properties
@@ -7,5 +7,5 @@ spring.mail.port=${SPRING_MAIL_PORT}
 spring.mail.username=${SPRING_MAIL_USERNAME}
 spring.mail.password=${SPRING_MAIL_PASSWORD}
 spring.mail.properties.mail.smtp.auth=${SPRING_MAIL_SMTP_AUTH}
-spring.mail.properties.mail.smtp.starttls.enable=${SPRING_MAIL_SMTP_STARTTLS_ENABLE}
+spring.mail.properties.mail.smtp.ssl.enable=${SPRING_MAIL_SMTP_SSL_ENABLE}
 gemini.api.key=${GEMINI_API_KEY}


### PR DESCRIPTION
This PR fixes an issue where emails were not being sent successfully from the ECS container due to the missing From address in the mail helper configuration.

Locally, emails were sent without explicitly setting the From address, since the local SMTP server handled defaults.
In ECS (with SES/SMTP), the email failed because AWS requires a verified sender address.

Changes Made:
Added helper.setFrom("your_verified_email@example.com"); to ensure all outgoing emails use the verified sender address.
This aligns with AWS SES requirements and ensures consistent behavior across environments (local & ECS).
Impact:
Emails will now be delivered reliably in ECS/Fargate.

Ensures compliance with SES verified sender policy.